### PR TITLE
Set working directory for codeql action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,8 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    defaults:
+      working-directory: ConcernsCaseWork
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Attempts to fix CodeQL scanner not working by setting working directory to where project solution is located.

This **should** allow CodeQL to intelligently run autobuild.

If this doesn't work, next steps are to manually configure build steps instead of using autobuild