### PR TITLE
Set working-directory properly on codeql workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,8 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     defaults:
-      working-directory: ConcernsCaseWork
+      run:
+        working-directory: ConcernsCaseWork
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Forgot to include the `run`  on #1203 which caused invalid workflow syntax