### PR TITLE
Add exclusion paths for build and test

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -4,9 +4,17 @@ on:
   push:
     branches:
     - main
+    paths:
+    - 'ConcernsCaseWork/ConcernsCaseWork.*'
+    - '!ConcernsCaseWork/ConcernsCaseWork.CypressTests'
+    - '*.csproj'
   pull_request:
     branches: [ main, release/** ]
     types: [ opened, synchronize, reopened ]
+    paths:
+    - 'ConcernsCaseWork/ConcernsCaseWork.*'
+    - '!ConcernsCaseWork/ConcernsCaseWork.CypressTests'
+    - '*.csproj'
 
 env:
   JAVA_VERSION: '17'


### PR DESCRIPTION
Sets paths to restrict when to run build and test.

This is to reduce the amount of times that sonarcloud is ran and to free up github runners