### PR TITLE
Standardise content max-width to match DFE Frontend

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/AccessDenied.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/AccessDenied.cshtml
@@ -6,14 +6,14 @@
     ViewData["Title"] = "Access denied";
     const string serviceDeskRequestLink = "https://forms.office.com/Pages/ResponsePage.aspx?id=yXfS-grGoU2187O4s0qC-X7F89QcWu5CjlJXwF0TVktUNVlZRUoxTlpPNDgxSVhSTjVHRDhXMFQzRSQlQCN0PWcu";
 }
-<div class="govuk-width-container">
-	
+<div class="dfe-width-container">
+
 	<partial name="_BannerError"/>
-	
+
 	<div class="moj-search govuk-grid-row">
 		<div class="govuk-grid-column-two-thirds">
 			<h1 class="govuk-heading-l">You do not have access to this service</h1>
-			<p class="govuk-body">If you think you need access, <a href="@serviceDeskRequestLink" class="govuk-link">submit an access request</a>.</p>			
+			<p class="govuk-body">If you think you need access, <a href="@serviceDeskRequestLink" class="govuk-link">submit an access request</a>.</p>
 		</div>
 	</div>
 </div>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Accessibility.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Accessibility.cshtml
@@ -7,12 +7,12 @@
     var prodSiteName = "record-concerns-support-trusts.education.gov.uk";
 }
 @section BeforeMain {
-    <div class="govuk-width-container">
+    <div class="dfe-width-container">
         <back-link url="@Model.BackLink.Url" label="@Model.BackLink.Label"></back-link>
     </div>
 }
 
-<div class="govuk-width-container">
+<div class="dfe-width-container">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
 
@@ -21,11 +21,11 @@
             <p class="govuk-body">This service is part of the wider GOV.UK website. There’s a separate <a target="_blank" href="https://www.gov.uk/help/accessibility-statement" class="govuk-link">accessibility statement for the main GOV.UK website</a>.</p>
 
             <p class="govuk-body">This page only contains information about the Record concerns and support for trusts service, available at <a target="_blank" href="@prodSiteLink" class="govuk-link">@prodSiteName</a></p>
-            
+
             <h2 class="govuk-heading-m">Using this service</h2>
             <p class="govuk-body">This accessibility statement applies to the domain <a target="_blank" href="@prodSiteLink" class="govuk-link">@prodSiteName</a></p>
 
-            
+
             <p class="govuk-body">This service is run by the Department for Education. We want as many people as possible to be able to use this service. For example, that means you should be able to do the following: </p>
             <ul class="govuk-list govuk-list--bullet">
                 <li>change colours, contrast levels and fonts</li>
@@ -57,7 +57,7 @@
 
             <h2 class="govuk-heading-m">Technical information about this service’s accessibility</h2>
             <p class="govuk-body">The Department for Education is committed to making this service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
-            
+
             <h2 class="govuk-heading-m">Compliance status</h2>
             <p class="govuk-body">This service is fully compliant with the <a target="_blank" href="https://www.w3.org/TR/WCAG21" class="govuk-link">Web Content Accessibility Guidelines version 2.1 AA standard</a>.</p>
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Cookies.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Cookies.cshtml
@@ -4,12 +4,12 @@
     ViewData["Title"] = "Cookies";
 }
 @section BeforeMain {
-	<div class="govuk-width-container">
+	<div class="dfe-width-container">
 		<back-link url="@Model.BackLink.Url" label="@Model.BackLink.Label"></back-link>
 	</div>
 }
 
-<div class="govuk-width-container">
+<div class="dfe-width-container">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds-from-desktop">
             <h1 class="govuk-heading-l govuk-!-margin-bottom-9">Cookies on Record concerns and support for trusts</h1>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Error.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Error.cshtml
@@ -7,32 +7,34 @@
     var errorDetails = GetErrorDetails();
 }
 
-<div class="govuk-width-container">
+<div class="dfe-width-container">
     <div class="govuk-grid-row">
-        <div id="moj-banner-error" class="govuk-!-display-none">
-            <div class="moj-banner__message">
-                <span class="moj-banner__assistive">Warning</span>
-                <h1>
-                    Sorry, there is a problem with the service
-                </h1>
-            </div>
-        </div>
-        <div class="govuk-heading-l moj-banner__message">
-            <p style="white-space: pre-line" class="govuk-body">@TempData["Error.Message"]</p>
-            @if (errorDetails?.Count() > 0)
-            {
-                <h2 class="govuk-heading-m govuk-!-margin-top-6">Error details</h2>
-                <div class="govuk-error-summary__body">
-                    <ul class="govuk-list govuk-error-summary__list">
-                        @foreach (var detail in errorDetails)
-                        {
-                            <li>
-                                <span class="govuk-error-message">@detail</span>
-                            </li>
-                        }
-                    </ul>
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            <div id="moj-banner-error" class="govuk-!-display-none">
+                <div class="moj-banner__message">
+                    <span class="moj-banner__assistive">Warning</span>
+                    <h1>
+                        Sorry, there is a problem with the service
+                    </h1>
                 </div>
-            }
+            </div>
+            <div class="govuk-heading-l moj-banner__message">
+                <p style="white-space: pre-line" class="govuk-body">@TempData["Error.Message"]</p>
+                @if (errorDetails?.Count() > 0)
+                {
+                    <h2 class="govuk-heading-m govuk-!-margin-top-6">Error details</h2>
+                    <div class="govuk-error-summary__body">
+                        <ul class="govuk-list govuk-error-summary__list">
+                            @foreach (var detail in errorDetails)
+                            {
+                                <li>
+                                    <span class="govuk-error-message">@detail</span>
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                }
+            </div>
         </div>
     </div>
 </div>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Maintenance.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Maintenance.cshtml
@@ -4,7 +4,7 @@
     Layout = null;
 }
 
-<div class="govuk-width-container">
+<div class="dfe-width-container">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <h1 class="govuk-heading-l">This service is unavailable</h1>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/NotFound.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/NotFound.cshtml
@@ -4,12 +4,12 @@
 	ViewData["Title"] = "No such page";
 }
 @section BeforeMain {
-	<div class="govuk-width-container">
+	<div class="dfe-width-container">
 		<back-link url="@Model.BackLink.Url" label="@Model.BackLink.Label"></back-link>
 	</div>
 }
 
-<div class="govuk-width-container">
+<div class="dfe-width-container">
 	<div class="govuk-grid-row">
 			<div class="govuk-grid-column-two-thirds">
 				<h1 class="govuk-heading-l">Page not found</h1>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/PrivacyPolicy.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/PrivacyPolicy.cshtml
@@ -4,12 +4,12 @@
 	ViewData["Title"] = "Privacy Policy";
 }
 @section BeforeMain {
-	<div class="govuk-width-container">
+	<div class="dfe-width-container">
 		<back-link url="@Model.BackLink.Url" label="@Model.BackLink.Label"></back-link>
 	</div>
 }
 
-<div class="govuk-width-container">
+<div class="dfe-width-container">
 	<div class="govuk-grid-row">
 		<div class="govuk-grid-column-two-thirds-from-desktop">
 
@@ -95,7 +95,7 @@
 
 			<p class="govuk-body">We do not identify you from these records unless needed - for example, to investigate an issue you raise.</p>
 
-			
+
 			<h3 class="govuk-heading-s">User research tools</h3>
 
 			<p class="govuk-body">If you agree to take part in user research, we’ll ask if you consent to use Lookback to carry out and record a video session with you.</p>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_Layout.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_Layout.cshtml
@@ -190,7 +190,7 @@
     </main>
 
     <footer class="govuk-footer " role="contentinfo">
-        <div class="govuk-width-container">
+        <div class="dfe-width-container">
             <div class="govuk-footer__meta">
                 <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
                     <h2 class="govuk-heading-m">Get support</h2>

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Trust/Index.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Trust/Index.cshtml
@@ -14,7 +14,7 @@
     };
 }
 
-<div class="govuk-width-container">
+<div class="dfe-width-container">
 
 	<partial name="_BannerError" />
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Trust/Overview.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Trust/Overview.cshtml
@@ -10,7 +10,7 @@
     var nonce = HttpContext.GetNonce();
 }
 
-<div class="govuk-width-container">
+<div class="dfe-width-container">
     <h1 class="govuk-heading-l">
         <span class="govuk-caption-m">Trust Overview</span>
         @Model.TrustOverviewModel.TrustDetailsModel.GiasData.GroupNameTitle


### PR DESCRIPTION
**What is the change?**
Sets the correct content width for shared and generic page layouts to `1200px`

**Why do we need the change?**
The DFE Header is 1200px but the footer and page layouts are still using the govuk page width which is 960px. This makes the page look a little odd as the header is far wider than the rest of the page elements.

**What is the impact?**
No impact, only HTML classes have changed.

**Azure DevOps Ticket**
N/A