### PR TITLE
improved the performance of the get case summary query

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -35,7 +35,7 @@ env:
 jobs:
   cypress-tests:
     name: Run Cypress Tests
-    if: inputs.environment == 'staging' || inputs == 'dev'
+    if: inputs.environment == 'staging' || inputs.environment == 'dev'
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     defaults:

--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Case/CaseSummaryConstants.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Case/CaseSummaryConstants.cs
@@ -8,6 +8,11 @@ namespace ConcernsCaseWork.API.Contracts.Case
 {
 	public static class CaseSummaryConstants
 	{
+		public const string Srma = "Action: School Resource Management Adviser";
+		public const string Nti = "Action: Notice To Improve";
+		public const string NtiWarningLetter = "Action: NTI warning letter";
+		public const string NtiUnderConsideration = "Action: NTI under consideration";
+		public const string FinancialPlan = "Action: Financial plan";
 		public const string TrustFinancialForecast = "Action: TFF (trust financial forecast)";
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress.config.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress.config.ts
@@ -7,7 +7,9 @@ export default defineConfig({
   watchForFileChanges: false,
   chromeWebSecurity: false,
   video: false,
-  retries: 1,
+  retries: {
+    runMode: 1
+  },
   reporter: 'cypress-multi-reporters',
   reporterOptions: {
     reporterEnabled: 'mochawesome',

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-non-concerns-case.cy.ts
@@ -56,17 +56,17 @@ describe("Creating a non concerns case", () => {
 		createCasePage.createCase().withTrustName(trustName).selectOption().confirmOption();
 
 		Logger.log("You must select a division error");
-        selectCaseDivisionPage
-            .continue()
-            .hasValidationError("Select case division");
+		selectCaseDivisionPage
+			.continue()
+			.hasValidationError("Select case division");
 
-        Logger.log("Checking accessibility on select case division");
-        cy.excuteAccessibilityTests();
+		Logger.log("Checking accessibility on select case division");
+		cy.excuteAccessibilityTests();
 
-        Logger.log("Create a valid case division");
-        selectCaseDivisionPage
-            .withCaseDivision("SFSO")
-            .continue();
+		Logger.log("Create a valid case division");
+		selectCaseDivisionPage
+			.withCaseDivision("SFSO")
+			.continue();
 
 		Logger.log("Populate territory");
 		addTerritoryPage.withTerritory(territory).nextStep();
@@ -122,6 +122,8 @@ describe("Creating a non concerns case", () => {
 			.hasDateTrustContacted("05 June 2022")
 			.hasNotes("This is my notes");
 
+
+
 		Logger.log("Closing SRMA");
 		viewSrmaPage.addReason();
 
@@ -146,46 +148,45 @@ describe("Creating a non concerns case", () => {
 		});
 	});
 
-	describe("Converting non conern to concern case", () =>
-	{
+	describe("Converting non concern to concern case", () => {
 		it("Should make the case a concerns case", () => {
 			Logger.log("Create a case");
 			createCasePage.createCase().withTrustName(trustName).selectOption().confirmOption();
-	
+
 			Logger.log("Create a valid case division");
 			selectCaseDivisionPage
 				.withCaseDivision("SFSO")
 				.continue();
-	
+
 			Logger.log("Populate territory");
 			addTerritoryPage.withTerritory(territory).nextStep();
-	
+
 			Logger.log("Create a valid Non-concern case type");
 			selectCaseTypePage.withCaseType("NonConcerns").continue();
-	
+
 			Logger.log("Add non concerns case");
 			addConcernDetailsPage.createCase();
-	
+
 			Logger.log("Add another concern after case creation");
 			caseManagementPage.addAnotherConcernForNonConcern();
-	
+
 			Logger.log("Checking accessibility on adding concern page");
 			cy.excuteAccessibilityTests();
-	
+
 			Logger.log("Attempt to create an invalid concern");
 			createConcernPage
 				.addConcern()
 				.hasValidationError("Select concern type")
 				.hasValidationError("Select concern risk rating")
 				.hasValidationError("Select means of referral");
-	
+
 			Logger.log("Create an invalid sub concern");
 			createConcernPage
 				.withConcernType("Deficit")
 				.withConcernRating("Red-Amber")
 				.withMeansOfReferral(SourceOfConcernExternal)
 				.addConcern();
-	
+
 			Logger.log("Adding another concern during case creation");
 			createConcernPage
 				.addAnotherConcern()
@@ -194,17 +195,17 @@ describe("Creating a non concerns case", () => {
 				.withMeansOfReferral(SourceOfConcernInternal)
 				.addConcern()
 				.nextStep();
-	
+
 			Logger.log("Check unpopulated risk to trust throws validation error");
 			addConcernDetailsPage
 				.nextStep()
 				.hasValidationError("Select risk to trust rating");
-	
+
 			createConcernPage.withConcernRating("Red Plus").nextStep();
-	
+
 			Logger.log("Checking accessibility on create case concern page");
 			cy.excuteAccessibilityTests();
-	
+
 			Logger.log("Validate unpopulated concern details");
 			addConcernDetailsPage
 				.withIssueExceedingLimit()
@@ -220,10 +221,10 @@ describe("Creating a non concerns case", () => {
 				.hasValidationError("De-escalation point must be 1000 characters or less")
 				.hasValidationError("Case aim must be 1000 characters or less")
 				.hasValidationError("Case notes must be 4300 characters or less");
-	
+
 			Logger.log("Checking accessibility on concerns case confirmation");
 			cy.excuteAccessibilityTests();
-	
+
 			Logger.log("Add concern details with valid text limit");
 			addConcernDetailsPage
 				.withIssue("This is an issue")
@@ -233,7 +234,7 @@ describe("Creating a non concerns case", () => {
 				.withNextSteps("This is the next steps")
 				.withCaseHistory("This is the case history")
 				.createCase();
-	
+
 			Logger.log("Verify case details");
 			caseManagementPage
 				.hasTrust("Ashton West End Primary Academy")
@@ -248,7 +249,7 @@ describe("Creating a non concerns case", () => {
 				.hasDeEscalationPoint("This is the de-escalation point")
 				.hasNextSteps("This is the next steps")
 				.hasCaseHistory("This is the case history");
-	
+
 			Logger.log("Verify the means of referral is set");
 			caseManagementPage.getCaseIDText().then((caseId) => {
 				concernsApi.get(parseInt(caseId)).then((response) => {
@@ -259,93 +260,90 @@ describe("Creating a non concerns case", () => {
 			});
 		});
 
-		describe("When we cancel case creation of a different case in the middle", () =>
-		{
-			it("Should create the concern against the correct case and trust", () =>
-			{
+		describe("When we cancel case creation of a different case in the middle", () => {
+			it("Should create the concern against the correct case and trust", () => {
 				Logger.log("Create a case");
 				createCasePage.createCase().withTrustName(trustName).selectOption().confirmOption();
-		
+
 				selectCaseDivisionPage
 					.withCaseDivision("SFSO")
 					.continue();
-		
+
 				addTerritoryPage.withTerritory(territory).nextStep();
 				selectCaseTypePage.withCaseType("NonConcerns").continue();
 				addConcernDetailsPage.createCase();
 
 				caseManagementPage.getCaseIDText()
-				.then((caseId: string) =>
-				{
-					headerComponent.goToHome();
+					.then((caseId: string) => {
+						headerComponent.goToHome();
 
-					Logger.log("Create a case for an alternative trust");
-					createCasePage.createCase().withTrustName(alternativeTrustName).selectOption().confirmOption();
-					
-					Logger.log("Create a concerns case for our original trust ensuring the data is correct");
-					cy.visit(`/case/${caseId}/management`);
-					caseManagementPage.addAnotherConcernForNonConcern();
+						Logger.log("Create a case for an alternative trust");
+						createCasePage.createCase().withTrustName(alternativeTrustName).selectOption().confirmOption();
 
-					createCaseSummary
-						.hasTrustSummaryDetails(trustName)
-						.hasManagedBy("SFSO", "North and UTC - North East");
+						Logger.log("Create a concerns case for our original trust ensuring the data is correct");
+						cy.visit(`/case/${caseId}/management`);
+						caseManagementPage.addAnotherConcernForNonConcern();
 
-					createConcernPage
-						.withConcernType("Viability")
-						.withConcernRating("Amber-Green")
-						.withMeansOfReferral(SourceOfConcernExternal)
-						.addConcern();
+						createCaseSummary
+							.hasTrustSummaryDetails(trustName)
+							.hasManagedBy("SFSO", "North and UTC - North East");
 
-					Logger.log("Exit early again and create another concern");
+						createConcernPage
+							.withConcernType("Viability")
+							.withConcernRating("Amber-Green")
+							.withMeansOfReferral(SourceOfConcernExternal)
+							.addConcern();
 
-					cy.visit(`/case/${caseId}/management`);
-					caseManagementPage.addAnotherConcernForNonConcern();
+						Logger.log("Exit early again and create another concern");
 
-					Logger.log("It should show us the trust for the case we are on");
+						cy.visit(`/case/${caseId}/management`);
+						caseManagementPage.addAnotherConcernForNonConcern();
 
-					createCaseSummary
-						.hasTrustSummaryDetails(trustName)
-						.hasManagedBy("SFSO", "North and UTC - North East");
+						Logger.log("It should show us the trust for the case we are on");
 
-					createConcernPage
-						.withConcernType("Deficit")
-						.withConcernRating("Red-Amber")
-						.withMeansOfReferral(SourceOfConcernExternal)
-						.addConcern();
+						createCaseSummary
+							.hasTrustSummaryDetails(trustName)
+							.hasManagedBy("SFSO", "North and UTC - North East");
 
-					createCaseSummary
-						.hasTrustSummaryDetails(trustName)
-						.hasManagedBy("SFSO", "North and UTC - North East")
-						.hasConcernType("Deficit")
-						.hasConcernRiskRating("Red Amber");
+						createConcernPage
+							.withConcernType("Deficit")
+							.withConcernRating("Red-Amber")
+							.withMeansOfReferral(SourceOfConcernExternal)
+							.addConcern();
 
-					createConcernPage.nextStep();
+						createCaseSummary
+							.hasTrustSummaryDetails(trustName)
+							.hasManagedBy("SFSO", "North and UTC - North East")
+							.hasConcernType("Deficit")
+							.hasConcernRiskRating("Red Amber");
 
-					createCaseSummary
-						.hasTrustSummaryDetails(trustName)
-						.hasManagedBy("SFSO", "North and UTC - North East")
-						.hasConcernType("Deficit")
-						.hasConcernRiskRating("Red Amber");
+						createConcernPage.nextStep();
 
-					createConcernPage.withConcernRating("Red Plus").nextStep();
+						createCaseSummary
+							.hasTrustSummaryDetails(trustName)
+							.hasManagedBy("SFSO", "North and UTC - North East")
+							.hasConcernType("Deficit")
+							.hasConcernRiskRating("Red Amber");
 
-					createCaseSummary
-						.hasTrustSummaryDetails(trustName)
-						.hasManagedBy("SFSO", "North and UTC - North East")
-						.hasConcernType("Deficit")
-						.hasConcernRiskRating("Red Amber")
-						.hasRiskToTrust("Red Plus");
+						createConcernPage.withConcernRating("Red Plus").nextStep();
 
-					addConcernDetailsPage
-						.withIssue("This is an issue").createCase();
+						createCaseSummary
+							.hasTrustSummaryDetails(trustName)
+							.hasManagedBy("SFSO", "North and UTC - North East")
+							.hasConcernType("Deficit")
+							.hasConcernRiskRating("Red Amber")
+							.hasRiskToTrust("Red Plus");
 
-					Logger.log("It should create just one concern against the correct trust");
-					caseManagementPage
-						.hasTrust(trustName)
-						.hasRiskToTrust("Red Plus")
-						.hasConcerns("Deficit", ["Red", "Amber"])
-						.hasNumberOfConcerns(1);
-				});
+						addConcernDetailsPage
+							.withIssue("This is an issue").createCase();
+
+						Logger.log("It should create just one concern against the correct trust");
+						caseManagementPage
+							.hasTrust(trustName)
+							.hasRiskToTrust("Red Plus")
+							.hasConcerns("Deficit", ["Red", "Amber"])
+							.hasNumberOfConcerns(1);
+					});
 			});
 		});
 	});
@@ -370,6 +368,7 @@ describe("Creating a non concerns case", () => {
 				.hasCreatedDate(toDisplayDate(now))
 				.hasClosedDate(toDisplayDate(now))
 				.hasTrust(trustName)
+				.hasAction("Action: School Resource Management Adviser")
 				.select();
 		});
 

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/smoke.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/smoke.cy.ts
@@ -101,7 +101,7 @@ describe("Smoke - Testing closing of cases when there are case actions and conce
 		createCaseSummary
 			.hasTrustSummaryDetails(trustName)
 			.hasManagedBy("SFSO", "");
-	
+
 		Logger.log("Populate territory");
 		addTerritoryPage.withTerritory("North and UTC - North East").nextStep();
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/CaseSummaryGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/CaseSummaryGateway.cs
@@ -38,7 +38,7 @@ public class CaseSummaryGateway : ICaseSummaryGateway
 			queryBuilder = queryBuilder.Paginate(parameters.Page.Value, parameters.Count.Value);
 		}
 
-		var caseIds = queryBuilder.Select(c => c.Id).ToList();
+		var caseIds = await queryBuilder.Select(c => c.Id).ToListAsync();
 
 		var cases = await SelectOpenCaseSummary(caseIds).AsSplitQuery().ToListAsync();
 
@@ -59,7 +59,7 @@ public class CaseSummaryGateway : ICaseSummaryGateway
 			queryBuilder = queryBuilder.Paginate(parameters.Page.Value, parameters.Count.Value);
 		}
 
-		var caseIds = queryBuilder.Select(c => c.Id).ToList();
+		var caseIds = await queryBuilder.Select(c => c.Id).ToListAsync();
 
 		var cases = await SelectOpenCaseSummary(caseIds).AsSplitQuery().ToListAsync();
 
@@ -80,7 +80,7 @@ public class CaseSummaryGateway : ICaseSummaryGateway
 			queryBuilder = queryBuilder.Paginate(parameters.Page.Value, parameters.Count.Value);
 		}
 
-		var caseIds = queryBuilder.Select(c => c.Id).ToList();
+		var caseIds = await queryBuilder.Select(c => c.Id).ToListAsync();
 
 		var cases = await SelectOpenCaseSummary(caseIds).AsSplitQuery().ToListAsync();
 
@@ -122,7 +122,7 @@ public class CaseSummaryGateway : ICaseSummaryGateway
 			queryBuilder = queryBuilder.Paginate(parameters.Page.Value, parameters.Count.Value);
 		}
 
-		var caseIds = queryBuilder.Select(c => c.Id).ToList();
+		var caseIds = await queryBuilder.Select(c => c.Id).ToListAsync();
 
 		var cases = await SelectClosedCaseSummary(caseIds).AsSplitQuery().ToListAsync();
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/CaseSummaryGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/CaseSummaryGateway.cs
@@ -101,7 +101,7 @@ public class CaseSummaryGateway : ICaseSummaryGateway
 			queryBuilder = queryBuilder.Paginate(parameters.Page.Value, parameters.Count.Value);
 		}
 
-		var caseIds = queryBuilder.Select(c => c.Id).ToList();
+		var caseIds = await queryBuilder.Select(c => c.Id).ToListAsync();
 
 		var cases = await SelectClosedCaseSummary(caseIds).AsSplitQuery().ToListAsync();
 

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/CaseSummaryGateway.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/Gateways/CaseSummaryGateway.cs
@@ -168,23 +168,23 @@ public class CaseSummaryGateway : ICaseSummaryGateway
 						select decisions,
 			FinancialPlanCases = _concernsDbContext.FinancialPlanCases
 				.Where(x => x.CaseUrn == cases.Urn && !x.ClosedAt.HasValue)
-				.Select(action => new CaseSummaryVm.Action(action.CreatedAt, null, "Action: Financial plan"))
+				.Select(action => new CaseSummaryVm.Action(action.CreatedAt, null, CaseSummaryConstants.FinancialPlan))
 				.ToArray(),
 			NtisUnderConsideration = _concernsDbContext.NTIUnderConsiderations
 				.Where(x => x.CaseUrn == cases.Urn && !x.ClosedAt.HasValue)
-				.Select(action => new CaseSummaryVm.Action(action.CreatedAt, null, "Action: NTI under consideration"))
+				.Select(action => new CaseSummaryVm.Action(action.CreatedAt, null, CaseSummaryConstants.NtiUnderConsideration))
 				.ToArray(),
 			NtiWarningLetters = _concernsDbContext.NTIWarningLetters
 				.Where(x => x.CaseUrn == cases.Urn && !x.ClosedAt.HasValue)
-				.Select(action => new CaseSummaryVm.Action(action.CreatedAt, null, "Action: NTI warning letter"))
+				.Select(action => new CaseSummaryVm.Action(action.CreatedAt, null, CaseSummaryConstants.NtiWarningLetter))
 				.ToArray(),
 			NoticesToImprove = _concernsDbContext.NoticesToImprove
 				.Where(x => x.CaseUrn == cases.Urn && !x.ClosedAt.HasValue)
-				.Select(action => new CaseSummaryVm.Action(action.CreatedAt, null, "Action: Notice To Improve"))
+				.Select(action => new CaseSummaryVm.Action(action.CreatedAt, null, CaseSummaryConstants.Nti))
 				.ToArray(),
 			SrmaCases = _concernsDbContext.SRMACases
 				.Where(x => x.CaseUrn == cases.Urn && !x.ClosedAt.HasValue)
-				.Select(action => new CaseSummaryVm.Action(action.CreatedAt, null, "Action: School Resource Management Adviser"))
+				.Select(action => new CaseSummaryVm.Action(action.CreatedAt, null, CaseSummaryConstants.Srma))
 				.ToArray(),
 			TrustFinancialForecasts = _concernsDbContext.TrustFinancialForecasts
 				.Where(x => x.CaseUrn == cases.Urn && !x.ClosedAt.HasValue)
@@ -204,10 +204,6 @@ public class CaseSummaryGateway : ICaseSummaryGateway
 
 	private IQueryable<ClosedCaseSummaryVm> SelectClosedCaseSummary(IQueryable<ConcernsCase> query)
 	{
-		var caseIds = query.Select(c => c.Urn).ToList();
-
-		query = query.Where(c => caseIds.Contains(c.Urn));
-
 		return query.Select(cases => new ClosedCaseSummaryVm
 		{
 			CaseUrn = cases.Urn,
@@ -227,23 +223,23 @@ public class CaseSummaryGateway : ICaseSummaryGateway
 			Decisions = from decisions in cases.Decisions select decisions,
 			FinancialPlanCases = _concernsDbContext.FinancialPlanCases
 							.Where(x => x.CaseUrn == cases.Urn)
-							.Select(action => new CaseSummaryVm.Action(action.CreatedAt, action.ClosedAt, "Action: Financial plan"))
+							.Select(action => new CaseSummaryVm.Action(action.CreatedAt, action.ClosedAt, CaseSummaryConstants.FinancialPlan))
 							.ToArray(),
 			NtisUnderConsideration = _concernsDbContext.NTIUnderConsiderations
 							.Where(x => x.CaseUrn == cases.Urn)
-							.Select(action => new CaseSummaryVm.Action(action.CreatedAt, action.ClosedAt, "Action: NTI under consideration"))
+							.Select(action => new CaseSummaryVm.Action(action.CreatedAt, action.ClosedAt, CaseSummaryConstants.NtiUnderConsideration))
 							.ToArray(),
 			NtiWarningLetters = _concernsDbContext.NTIWarningLetters
 							.Where(x => x.CaseUrn == cases.Urn)
-							.Select(action => new CaseSummaryVm.Action(action.CreatedAt, action.ClosedAt, "Action: NTI warning letter"))
+							.Select(action => new CaseSummaryVm.Action(action.CreatedAt, action.ClosedAt, CaseSummaryConstants.NtiWarningLetter))
 							.ToArray(),
 			NoticesToImprove = _concernsDbContext.NoticesToImprove
 							.Where(x => x.CaseUrn == cases.Urn)
-							.Select(action => new CaseSummaryVm.Action(action.CreatedAt, action.ClosedAt, "Action: Notice To Improve"))
+							.Select(action => new CaseSummaryVm.Action(action.CreatedAt, action.ClosedAt, CaseSummaryConstants.Nti))
 							.ToArray(),
 			SrmaCases = _concernsDbContext.SRMACases
 							.Where(x => x.CaseUrn == cases.Urn)
-							.Select(action => new CaseSummaryVm.Action(action.CreatedAt, action.ClosedAt, "Action: School Resource Management Adviser"))
+							.Select(action => new CaseSummaryVm.Action(action.CreatedAt, action.ClosedAt, CaseSummaryConstants.Srma))
 							.ToArray(),
 			TrustFinancialForecasts = _concernsDbContext.TrustFinancialForecasts
 							.Where(x => x.CaseUrn == cases.Urn)

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Closed.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Closed.cshtml
@@ -87,7 +87,7 @@
 
                                 @if (!closedCase.ClosedConcerns.Any() && closedCase.ClosedActionsAndDecisions.Any())
                                 {
-                                    <td class="govuk-table__cell">
+                                    <td class="govuk-table__cell" data-testid="actions-and-decisions">
                                         <div class="concerns-secondary-text-colour">Actions and decisions</div>
                                         <ul class="govuk-list govuk-list--bullet">
                                             @foreach (var action in closedCase.ClosedActionsAndDecisions)

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesActive.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Shared/_CasesActive.cshtml
@@ -49,7 +49,7 @@
 
                     @if (!activeCase.ActiveConcerns.Any() && activeCase.ActiveActionsAndDecisions.Any())
                     {
-                        <td class="govuk-table__cell">
+                        <td class="govuk-table__cell" data-testid="actions-and-decisions">
                             <div class="concerns-secondary-text-colour">Actions and decisions</div>
                             <ul class="govuk-list govuk-list--bullet">
                                 @foreach (var action in activeCase.ActiveActionsAndDecisions)


### PR DESCRIPTION
**What is the change?**

when querying for open and closed case summaries, we use a split query to split a large query into multiple smaller ones. The problem is those smaller queries were too complicated and resulted in poor performance when there are a large number of records

This has been improved to query the cases we need by the filter criteria and then use that list of case ids in all sub queries, which is more performant for the sub queries. This is because the sub queries do not have to apply the more expensive filter each time and get the data using the indexed id

This was caught by automation, it also reduces the complexity of the queries that are running

**Why do we need the change?**

When a user has many cases performance can be impacted, mostly this is for our automated tests

**What is the impact?**

should be like for like in functionality

**Azure DevOps Ticket**
