### PR TITLE
concerns can now use the v4 academies api

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Configuration/FeatureFlags.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Configuration/FeatureFlags.cs
@@ -2,9 +2,7 @@
 {
 	public static class FeatureFlags
 	{
-		public const string IsRegionsGroupEnabled = "IsRegionsGroupEnabled";
 		public const string IsTrustSearchV4Enabled = "IsTrustSearchV4Enabled";
-		public const string IsSelectTeamCaseWorkRedesignEnabled = "IsSelectTeamCaseWorkRedesignEnabled";
 		public const string IsMaintenanceModeEnabled = "IsMaintenanceModeEnabled";
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/support/e2e.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/support/e2e.ts
@@ -26,7 +26,7 @@ declare global {
             getById(id: string): Chainable<Element>;
             login(params?: AuthenticationInterceptorParams): Chainable<Element>;
             loginWithCredentials(): Chainable<Element>;
-			excuteAccessibilityTests(): Chainable<Element>;
+            excuteAccessibilityTests(): Chainable<Element>;
             basicCreateCase(request?: CreateCaseRequest): Chainable<CreateCaseResponse>;
             createNonConcernsCase(request?: CreateCaseRequest): Chainable<CreateCaseResponse>;
             closeCase(): Chainable<Element>;

--- a/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/Trusts/TrustServiceTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service.Tests/Trusts/TrustServiceTests.cs
@@ -215,13 +215,13 @@ namespace ConcernsCaseWork.Service.Tests.Trusts
 			Assert.ThrowsAsync<HttpRequestException>(() => trustService.GetTrustsByPagination(TrustFactory.BuildTrustSearch(), 100));
 		}
 
-		[TestCase("", "", "", "page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
-		[TestCase("group-name", "", "", "groupName%3dgroup-name%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
-		[TestCase("", "ukprn", "", "page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
-		[TestCase("", "1234", "", "ukprn%3d1234%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
-		[TestCase("", "", "companies-house-number", "companiesHouseNumber%3dcompanies-house-number%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
-		[TestCase("group-name", "ukprn", "", "groupName%3dgroup-name%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
-		[TestCase("group-name", "1234", "", "groupName%3dgroup-name%26ukprn%3d1234%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("", "", "", "status%3dall%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("group-name", "", "", "status%3dall%26groupName%3dgroup-name%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("", "ukprn", "", "status%3dall%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("", "1234", "", "status%3dall%26ukprn%3d1234%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("", "", "companies-house-number", "status%3dall%26companiesHouseNumber%3dcompanies-house-number%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("group-name", "ukprn", "", "status%3dall%26groupName%3dgroup-name%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
+		[TestCase("group-name", "1234", "", "status%3dall%26groupName%3dgroup-name%26ukprn%3d1234%26page%3d1%26count%3d45%26includeEstablishments%3dFalse")]
 		public void WhenBuildRequestUri_ReturnsRequestUrl(string groupName, string ukprn, string companiesHouseNumber, string expectedRequestUri)
 		{
 			// arrange

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/EstablishmentV4Dto.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/EstablishmentV4Dto.cs
@@ -40,12 +40,15 @@ namespace ConcernsCaseWork.Service.Trusts
 		[JsonProperty("schoolCapacity")]
 		public virtual string SchoolCapacity { get; set; }
 
-		[JsonConstructor]
-		public EstablishmentV4Dto(string urn, string localAuthorityCode, string localAuthorityName,
-			string establishmentNumber, string establishmentName, string headteacherTitle, string headteacherFirstName, string headteacherLastName, EstablishmentTypeDto establishmentType, CensusDto census, string schoolWebsite, string schoolCapacity) =>
-			(Urn, LocalAuthorityCode, LocalAuthorityName, EstablishmentNumber, EstablishmentName, HeadteacherTitle, HeadteacherFirstName, HeadteacherLastName, EstablishmentType, Census, SchoolWebsite, SchoolCapacity) =
-			(urn, localAuthorityCode, localAuthorityName, establishmentNumber, establishmentName, headteacherTitle, headteacherFirstName, headteacherLastName, establishmentType, census, schoolWebsite, schoolCapacity);
+		[JsonProperty("misEstablishments")]
+		public MisEstablishmentsV4 MisEstablishments { get; set; } = new();
 
 		protected EstablishmentV4Dto() { }
+	}
+
+	public class  MisEstablishmentsV4
+	{
+		[JsonProperty("webLink")]
+		public virtual string SchoolWebsite { get; set; }
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/TrustSearchV4Dto.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/TrustSearchV4Dto.cs
@@ -22,12 +22,6 @@ namespace ConcernsCaseWork.Service.Trusts
 		[JsonProperty("address")]
 		public virtual GroupContactAddressDto GroupContactAddress { get; set; }
 
-		[JsonConstructor]
-		public TrustSearchV4Dto(string ukprn, string urn, string groupName,
-			string companiesHouseNumber, string trustType, GroupContactAddressDto groupContactAddress) =>
-			(UkPrn, Urn, GroupName, CompaniesHouseNumber, TrustType, GroupContactAddress) =
-			(ukprn, urn, groupName, companiesHouseNumber, trustType, groupContactAddress);
-
 		public TrustSearchV4Dto() { }
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/TrustService.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Service/Trusts/TrustService.cs
@@ -40,6 +40,8 @@ namespace ConcernsCaseWork.Service.Trusts
 		{
 			var queryParams = HttpUtility.ParseQueryString(string.Empty);
 
+			queryParams.Add("status", "all");
+
 			if (!string.IsNullOrEmpty(trustSearch.GroupName))
 			{
 				queryParams.Add("groupName", trustSearch.GroupName);
@@ -166,7 +168,7 @@ namespace ConcernsCaseWork.Service.Trusts
 
 		private async Task<List<EstablishmentDto>> GetEstablishments(string ukPrn)
 		{
-			var establishmentResponse = await PerformGet<List<EstablishmentV4Dto>>($"/v4/establishments/trust?trustUkprn={ukPrn}");
+			var establishmentResponse = await PerformGet<List<EstablishmentV4Dto>>($"/{EndpointV4}/establishments/trust?trustUkprn={ukPrn}");
 
 			var result = establishmentResponse.Select(e =>
 			{
@@ -180,7 +182,7 @@ namespace ConcernsCaseWork.Service.Trusts
 					HeadteacherLastName = e.HeadteacherLastName,
 					EstablishmentType = e.EstablishmentType,
 					Census = e.Census,
-					SchoolWebsite = e.SchoolWebsite,
+					SchoolWebsite = e.MisEstablishments.SchoolWebsite,
 					SchoolCapacity = e.SchoolCapacity,
 					LocalAuthorityName = e.LocalAuthorityName,
 				};

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseDivision.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseDivision.cshtml.cs
@@ -23,7 +23,6 @@ public class SelectCaseDivisionPageModel : CreateCaseBasePageModel
 	private readonly ITrustModelService _trustModelService;
 	private readonly IUserStateCachedService _cachedUserService;
 	private readonly ILogger<SelectCaseDivisionPageModel> _logger;
-	private readonly IFeatureManager _featureManager;
 
 	[BindProperty(SupportsGet = true)]
 	public TrustAddressModel TrustAddress { get; set; }
@@ -34,13 +33,11 @@ public class SelectCaseDivisionPageModel : CreateCaseBasePageModel
 	public SelectCaseDivisionPageModel(ITrustModelService trustModelService,
 		IUserStateCachedService cachedUserService,
 		ILogger<SelectCaseDivisionPageModel> logger,
-		IClaimsPrincipalHelper claimsPrincipalHelper,
-		IFeatureManager featureManager) : base(cachedUserService, claimsPrincipalHelper)
+		IClaimsPrincipalHelper claimsPrincipalHelper) : base(cachedUserService, claimsPrincipalHelper)
 	{
 		_trustModelService = trustModelService;
 		_cachedUserService = cachedUserService;
 		_logger = logger;
-		_featureManager = featureManager;
 	}
 
 	public async Task<IActionResult> OnGet()
@@ -101,7 +98,7 @@ public class SelectCaseDivisionPageModel : CreateCaseBasePageModel
 		return Page();
 	}
 
-	private async Task <RadioButtonsUiComponent> BuildCaseManagerComponent(int? selectedId = null)
+	private RadioButtonsUiComponent BuildCaseManagerComponent(int? selectedId = null)
 	{
 		var radioItems = new List<SimpleRadioItem>()
 		{
@@ -123,6 +120,6 @@ public class SelectCaseDivisionPageModel : CreateCaseBasePageModel
 		var userState = await GetUserState();
 		TrustAddress = await _trustModelService.GetTrustAddressByUkPrn(userState.TrustUkPrn);
 
-		CaseDivision = await BuildCaseManagerComponent(CaseDivision?.SelectedId);
+		CaseDivision = BuildCaseManagerComponent(CaseDivision?.SelectedId);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseDivision.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/CreateCase/SelectCaseDivision.cshtml.cs
@@ -103,12 +103,10 @@ public class SelectCaseDivisionPageModel : CreateCaseBasePageModel
 
 	private async Task <RadioButtonsUiComponent> BuildCaseManagerComponent(int? selectedId = null)
 	{
-		var isRegionsGroupEnabled = await _featureManager.IsEnabledAsync(nameof(FeatureFlags.IsRegionsGroupEnabled));
-
 		var radioItems = new List<SimpleRadioItem>()
 		{
 			new SimpleRadioItem("SFSO (Schools Financial Support and Oversight)", (int)Division.SFSO) { TestId = Division.SFSO.ToString() },
-			new SimpleRadioItem("Regions Group", (int)Division.RegionsGroup) { TestId = Division.RegionsGroup.ToString(), Disabled = !isRegionsGroupEnabled },
+			new SimpleRadioItem("Regions Group", (int)Division.RegionsGroup) { TestId = Division.RegionsGroup.ToString() },
 		};
 
 		return new(ElementRootId: "case-division", Name: nameof(CaseDivision), "Who is managing this case?")

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Team/SelectColleagues.cshtml
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Team/SelectColleagues.cshtml
@@ -27,59 +27,18 @@
         {
             <form asp-page-handler="selectColleagues" method="post" id="edit-selected-colleagues-form" novalidate>
 
-                @{
-                    <feature name="@FeatureFlags.IsSelectTeamCaseWorkRedesignEnabled">
-                        <h1 class="govuk-heading-l">Select case owners</h1>
-                        <div class="govuk-hint">Find and select the case owner's name or email address to see their open cases. You can add as many case owners as you like.</div>
+                <h1 class="govuk-heading-l">Select case owners</h1>
+                <div class="govuk-hint">Find and select the case owner's name or email address to see their open cases. You can add as many case owners as you like.</div>
 
-                        <div class="govuk-form-group @errorBannerClass" id="container-SelectedCaseOwner">
-                            <label for="select-colleagues-input" class="govuk-visually-hidden">Enter the email address of the person you want to assign the case to</label>
-                            <div id="autocomplete-container" class="@inputErrorClass"></div>
-                        </div>
+                <div class="govuk-form-group @errorBannerClass" id="container-SelectedCaseOwner">
+                    <label for="select-colleagues-input" class="govuk-visually-hidden">Enter the email address of the person you want to assign the case to</label>
+                    <div id="autocomplete-container" class="@inputErrorClass"></div>
+                </div>
 
-                        <div id="selected-colleagues-container">
-                            <partial name="_ColleaguesTable" model="Model.SelectedColleagues" />
-                        </div>
-                    </feature>
-                    <feature name="@FeatureFlags.IsSelectTeamCaseWorkRedesignEnabled" negate="true">
-                        <div class="govuk-form-group">
+                <div id="selected-colleagues-container">
+                    <partial name="_ColleaguesTable" model="Model.SelectedColleagues" />
+                </div>
 
-                            <h1 class="govuk-heading-l">Select colleagues to show in team casework</h1>
-
-                            <fieldset class="govuk-fieldset" aria-describedby="user-hint">
-                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                                    <h1 class="govuk-fieldset__heading">
-                                        Colleagues
-                                    </h1>
-                                </legend>
-                                <div id="user-hint" class="govuk-hint">
-                                    Select which colleagues you wish to see casework for.
-                                </div>
-
-                                <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-                                    @{
-                                        var idUser = 0;
-                                    }
-                                    @foreach (var user in Model.Users)
-                                    {
-                                        <div class="govuk-checkboxes__item">
-                                            @{
-                                                var idStr = idUser == 0 ? "user" : "user-" + idUser;
-                                                var checkedUser = Model.SelectedColleagues.Contains(user);
-                                            }
-                                            <input class="govuk-checkboxes__input" id="@idStr" name="SelectedColleagues" type="checkbox" value="@user" checked="@checkedUser">
-                                            <label class="govuk-label govuk-checkboxes__label" for="@idStr">
-                                                @user
-                                            </label>
-                                        </div>
-                                        idUser++;
-                                    }
-                                </div>
-                            </fieldset>
-                        </div>
-
-                    </feature>
-                }
 
                 <!--Button group-->
                 <div class="govuk-button-group">

--- a/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
+++ b/ConcernsCaseWork/ConcernsCaseWork/appsettings.json
@@ -59,9 +59,8 @@
 		"ConnectionString": "secret"
 	},
 	"FeatureManagement": {
-		"IsV3TrustSearchEnabled": true,
-		"IsCTCInTrustSearchEnabled": true,
-		"IsMaintenanceModeEnabled":  false
+		"IsMaintenanceModeEnabled": false,
+		"IsTrustSearchV4Enabled": false
 	},
 	"FakeTrusts": {
 		"Trusts": [


### PR DESCRIPTION
**What is the change?**

the api can be switched between v3 and v4, using a feature flag IsTrustSearchV4Enabled

removed the regions group feature flag
removed the casework feature flag and the legacy code

**Why do we need the change?**

move concerns over to the latest version of the academies api

**What is the impact?**

the impact has been mitigated by a feature flag that can switch it back if there is a problem

**Azure DevOps Ticket**
