### PR TITLE
Pin to 8.0.x for upstream security updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ﻿# Stage 1
-ARG ASPNET_IMAGE_TAG=8.0.0-bookworm-slim
+ARG ASPNET_IMAGE_TAG=8.0-bookworm-slim
 ARG NODEJS_IMAGE_TAG=16-bullseye
 ARG COMMIT_SHA=not-set
 


### PR DESCRIPTION
Tracking the minor version ensures we can receive all upstream security patches from Microsoft such as for:
• [CVE-2024-21392](https://github.com/advisories/GHSA-5fxj-whcv-crrc)
• [CVE-2024-21386](https://github.com/advisories/GHSA-g74q-5xw3-j7q9)