### PR TITLE
Configure HSTS settings for ASP.NET

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
@@ -114,6 +114,15 @@ namespace ConcernsCaseWork
 			{
 				options.ConnectionString = Configuration["ApplicationInsights:ConnectionString"];
 			});
+
+			// Enforce HTTPS in ASP.NET Core
+			// @link https://learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?
+			services.AddHsts(options =>
+			{
+				options.Preload = true;
+				options.IncludeSubDomains = true;
+				options.MaxAge = TimeSpan.FromDays(365);
+			});
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -132,7 +141,6 @@ namespace ConcernsCaseWork
 				app.UseExceptionHandler("/Error");
 			}
 
-			// The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
 			app.UseHsts();
 
 			app.UseMiddleware<ExceptionHandlerMiddleware>();


### PR DESCRIPTION
This PR simply adds the configuration overrides for the useHsts() method.
This allows us to set the max-age parameter to 365 days, and turn on preload.