### PR TITLE
Remove duplicate HSTS definition

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Security/SecurityHeadersDefinitionsTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Security/SecurityHeadersDefinitionsTests.cs
@@ -21,39 +21,39 @@ namespace ConcernsCaseWork.Tests.Security
 			Assert.That(headerPolicyCollection.ContainsKey("X-Frame-Options"), Is.True);
 			headerPolicyCollection.TryGetValue("X-Frame-Options", out var xFrameOptions);
 			Assert.That(xFrameOptions, Is.AssignableFrom<XFrameOptionsHeader>());
-			
+
 			Assert.That(headerPolicyCollection.ContainsKey("X-XSS-Protection"), Is.True);
 			headerPolicyCollection.TryGetValue("X-XSS-Protection", out var xssProtection);
 			Assert.That(xssProtection, Is.AssignableFrom<XssProtectionHeader>());
-			
+
 			Assert.That(headerPolicyCollection.ContainsKey("X-Content-Type-Options"), Is.True);
 			headerPolicyCollection.TryGetValue("X-Content-Type-Options", out var xContentTypeOptions);
 			Assert.That(xContentTypeOptions, Is.AssignableFrom<XContentTypeOptionsHeader>());
-			
+
 			Assert.That(headerPolicyCollection.ContainsKey("Referrer-Policy"), Is.True);
 			headerPolicyCollection.TryGetValue("Referrer-Policy", out var referrerPolicy);
 			Assert.That(referrerPolicy, Is.AssignableFrom<ReferrerPolicyHeader>());
-			
+
 			Assert.That(headerPolicyCollection.ContainsKey("Server"), Is.True);
 			headerPolicyCollection.TryGetValue("Server", out var server);
 			Assert.That(server, Is.AssignableFrom<ServerHeader>());
-			
+
 			Assert.That(headerPolicyCollection.ContainsKey("Cross-Origin-Opener-Policy"), Is.True);
 			headerPolicyCollection.TryGetValue("Cross-Origin-Opener-Policy", out var crossOriginOpenerPolicy);
 			Assert.That(crossOriginOpenerPolicy, Is.InstanceOf<CrossOriginOpenerPolicyHeader>());
-			
+
 			Assert.That(headerPolicyCollection.ContainsKey("Cross-Origin-Embedder-Policy"), Is.True);
 			headerPolicyCollection.TryGetValue("Cross-Origin-Embedder-Policy", out var crossOriginEmbedderPolicy);
 			Assert.That(crossOriginEmbedderPolicy, Is.InstanceOf<CrossOriginEmbedderPolicyHeader>());
-			
+
 			Assert.That(headerPolicyCollection.ContainsKey("Cross-Origin-Resource-Policy"), Is.True);
 			headerPolicyCollection.TryGetValue("Cross-Origin-Resource-Policy", out var crossOriginResourcePolicy);
 			Assert.That(crossOriginResourcePolicy, Is.InstanceOf<CrossOriginResourcePolicyHeader>());
-			
+
 			Assert.That(headerPolicyCollection.ContainsKey("Content-Security-Policy"), Is.True);
 			headerPolicyCollection.TryGetValue("Content-Security-Policy", out var contentSecurityPolicy);
 			Assert.That(contentSecurityPolicy, Is.InstanceOf<ContentSecurityPolicyHeader>());
-			
+
 			Assert.That(headerPolicyCollection.ContainsKey("Permissions-Policy"), Is.True);
 			headerPolicyCollection.TryGetValue("Permissions-Policy", out var permissionsPolicy);
 			Assert.That(permissionsPolicy, Is.InstanceOf<PermissionsPolicyHeader>());

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Security/SecurityHeadersDefinitionsTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Security/SecurityHeadersDefinitionsTests.cs
@@ -16,7 +16,7 @@ namespace ConcernsCaseWork.Tests.Security
 
 			// assert
 			Assert.That(headerPolicyCollection, Is.Not.Null);
-			Assert.That(headerPolicyCollection.Count, Is.EqualTo(11));
+			Assert.That(headerPolicyCollection.Count, Is.EqualTo(10));
 
 			Assert.That(headerPolicyCollection.ContainsKey("X-Frame-Options"), Is.True);
 			headerPolicyCollection.TryGetValue("X-Frame-Options", out var xFrameOptions);

--- a/ConcernsCaseWork/ConcernsCaseWork.Tests/Security/SecurityHeadersDefinitionsTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Tests/Security/SecurityHeadersDefinitionsTests.cs
@@ -57,13 +57,6 @@ namespace ConcernsCaseWork.Tests.Security
 			Assert.That(headerPolicyCollection.ContainsKey("Permissions-Policy"), Is.True);
 			headerPolicyCollection.TryGetValue("Permissions-Policy", out var permissionsPolicy);
 			Assert.That(permissionsPolicy, Is.InstanceOf<PermissionsPolicyHeader>());
-
-			if (!isDev)
-			{
-				Assert.That(headerPolicyCollection.ContainsKey("Strict-Transport-Security"), Is.True);
-				headerPolicyCollection.TryGetValue("Strict-Transport-Security", out var strictTransportSecurity);
-				Assert.That(strictTransportSecurity, Is.InstanceOf<StrictTransportSecurityHeader>());
-			}
 		}
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork/Security/SecurityHeadersDefinitions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Security/SecurityHeadersDefinitions.cs
@@ -58,8 +58,6 @@ namespace ConcernsCaseWork.Security
 					builder.AddUsb().None();
 				});
 
-			// max age = one year in seconds
-			policy.AddStrictTransportSecurityMaxAgeIncludeSubDomains(maxAgeInSeconds: 60 * 60 * 24 * 365);
 			return policy;
 		}
 	}


### PR DESCRIPTION
**What is the change?**
Removes the HSTS header definition from the security headers middleware

**Why do we need the change?**
This is built-in to dotnet so we can rely on the useHsts() method instead.

**What is the impact?**
None

**Azure DevOps Ticket**
N/A