### PR TITLE
Change priority order of Hsts header

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
@@ -128,6 +128,15 @@ namespace ConcernsCaseWork
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IApiVersionDescriptionProvider provider, IMapper mapper)
 		{
+			// Ensure we do not lose X-Forwarded-* Headers when behind a Proxy
+			var forwardOptions = new ForwardedHeadersOptions {
+				ForwardedHeaders = ForwardedHeaders.All,
+				RequireHeaderSymmetry = false
+			};
+			forwardOptions.KnownNetworks.Clear();
+			forwardOptions.KnownProxies.Clear();
+			app.UseForwardedHeaders(forwardOptions);
+
 			AbstractPageModel.PageHistoryStorageHandler = app.ApplicationServices.GetService<IPageHistoryStorageHandler>();
 
 			app.UseConcernsCaseworkSwagger(provider);
@@ -153,12 +162,6 @@ namespace ConcernsCaseWork
 			app.UseStatusCodePagesWithReExecute("/error/{0}");
 
 			app.UseHttpsRedirection();
-
-			//For Azure AD redirect uri to remain https
-			var forwardOptions = new ForwardedHeadersOptions { ForwardedHeaders = ForwardedHeaders.All, RequireHeaderSymmetry = false };
-			forwardOptions.KnownNetworks.Clear();
-			forwardOptions.KnownProxies.Clear();
-			app.UseForwardedHeaders(forwardOptions);
 
 			app.UseStaticFiles();
 

--- a/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
@@ -141,14 +141,13 @@ namespace ConcernsCaseWork
 				app.UseExceptionHandler("/Error");
 			}
 
-			app.UseHsts();
-
 			app.UseMiddleware<ExceptionHandlerMiddleware>();
 			app.UseMiddleware<ApiKeyMiddleware>();
 
 			// Security headers
 			app.UseSecurityHeaders(
 				SecurityHeadersDefinitions.GetHeaderPolicyCollection(env.IsDevelopment()));
+			app.UseHsts();
 
 			// Combined with razor routing 404 display custom page NotFound
 			app.UseStatusCodePagesWithReExecute("/error/{0}");


### PR DESCRIPTION
**What is the change?**
Moves `UseHsts` to below `UseSecurityHeaders` so that aspnet can add the header onto the response.

**Why do we need the change?**
When `UseSecurityHeaders` is invoked, the middleware will strip all existing response headers to set its own collection.

We also need to ensure the `UseForwadedHeaders` comes before any HTTP Header manipulation

**What is the impact?**
None

**Azure DevOps Ticket**
N/A

![Screenshot 2024-07-05 at 11 21 28](https://github.com/DFE-Digital/record-concerns-support-trusts/assets/3853061/6c94d39f-4cd1-403e-adeb-2e069bf647cf)
**before**

![Screenshot 2024-07-05 at 11 21 37](https://github.com/DFE-Digital/record-concerns-support-trusts/assets/3853061/56eac8f4-9a16-433c-b71b-c8260b58eb2f)
**after**