### PR TITLE
Setup Swagger after HTTP response middleware

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
@@ -139,8 +139,6 @@ namespace ConcernsCaseWork
 
 			AbstractPageModel.PageHistoryStorageHandler = app.ApplicationServices.GetService<IPageHistoryStorageHandler>();
 
-			app.UseConcernsCaseworkSwagger(provider);
-
 			if (env.IsDevelopment())
 			{
 				app.UseDeveloperExceptionPage();
@@ -157,6 +155,9 @@ namespace ConcernsCaseWork
 			app.UseSecurityHeaders(
 				SecurityHeadersDefinitions.GetHeaderPolicyCollection(env.IsDevelopment()));
 			app.UseHsts();
+
+			// Register Swagger Provider
+			app.UseConcernsCaseworkSwagger(provider);
 
 			// Combined with razor routing 404 display custom page NotFound
 			app.UseStatusCodePagesWithReExecute("/error/{0}");


### PR DESCRIPTION
**What is the change?**
Register swagger middleware after security headers are defined

**Why do we need the change?**
So that Swagger UI inherits the same security headers as the main app

**What is the impact?**
None

**Azure DevOps Ticket**
N/A