### PR TITLE
Ensure session cookie has 'secure' flag set

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
@@ -104,6 +104,7 @@ namespace ConcernsCaseWork
 				options.Cookie.Name = ".ConcernsCasework.Session";
 				options.Cookie.HttpOnly = true;
 				options.Cookie.IsEssential = true;
+				options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
 			});
 
 			services.AddRouting(options =>


### PR DESCRIPTION
**What is the change?**
Set 'secure' flag on Session cookie

**Why do we need the change?**
All cookies set by the application must have httpOnly and secure flags set to adhere to recommended remediations in the 2024 ITHC.

**What is the impact?**
Will only take affect when existing cookies expire or are cleared

**Azure DevOps Ticket**
#171441 [ITHC] 6.1.6. Cookie misconfiguration