### PR TITLE
Set 'secure' flag on Anti Forgery cookie

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Startup.cs
@@ -80,6 +80,11 @@ namespace ConcernsCaseWork
 					options.AccessDeniedPath = "/access-denied";
 				});
 
+			services.AddAntiforgery(options =>
+			{
+				options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+			});
+
 			// Redis
 			services.AddRedis(Configuration);
 


### PR DESCRIPTION
**What is the change?**
Set 'secure' flag on .AspNetCore.Antiforgery cookie

**Why do we need the change?**
All cookies set by the application must have httpOnly and secure flags set to adhere to recommended remediations in the 2024 ITHC.

**What is the impact?**
Will only take affect when existing cookies expire or are cleared

**Azure DevOps Ticket**
#171441 [ITHC] 6.1.6. Cookie misconfiguration