### PR TITLE
Set 'HttpOnly' on Cookie Consent Cookie

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Cookies.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Cookies.cshtml.cs
@@ -15,7 +15,7 @@ namespace ConcernsCaseWork.Pages
 
 		[BindProperty]
 		public bool HasConsented { get; set; }
-		
+
 		public Hyperlink BackLink => BuildBackLinkFromHistory(fallbackUrl: PageRoutes.YourCaseworkHomePage);
 
 		public CookiesPageModel(ILogger<CookiesPageModel> logger)

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Cookies.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Cookies.cshtml.cs
@@ -37,7 +37,11 @@ namespace ConcernsCaseWork.Pages
 		{
 			_logger.LogMethodEntered();
 
-			var cookieOptions = new CookieOptions { Expires = DateTime.Today.AddMonths(6), Secure = true };
+			var cookieOptions = new CookieOptions {
+				Expires = DateTime.Today.AddMonths(6),
+				Secure = true,
+				HttpOnly = true,
+			};
 
 			if (bannerConsent != null)
 			{


### PR DESCRIPTION
**What is the change?**
Sets the HttpOnly option to true when setting the consent cookie

**Why do we need the change?**
All cookies set by the application must have httpOnly and secure flags set to adhere to recommended remediations in the 2024 ITHC.

**What is the impact?**
Will only take affect when existing cookies expire or are cleared

**Azure DevOps Ticket**
#171441 [ITHC] 6.1.6. Cookie misconfiguration