### PR TITLE
Added a SQL Command interceptor to log executing commands in debug mode

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/ConcernsCaseWork.Data.Tests.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/ConcernsCaseWork.Data.Tests.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="NBuilder" Version="6.1.0" />
         <PackageReference Include="NUnit" Version="3.14.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/DatabaseFixtureBase.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/DatabaseFixtureBase.cs
@@ -1,20 +1,20 @@
 using ConcernsCaseWork.UserContext;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 
 namespace ConcernsCaseWork.Data.Tests;
 
 public class DatabaseTestFixture
 {
-	private readonly string? _connectionString;
+	public readonly string? _connectionString;
 
 	private static readonly object _lock = new();
 	private static bool _databaseInitialized;
 
-	protected DatabaseTestFixture()
+	public DatabaseTestFixture(IEnumerable<IInterceptor>? interceptors = null)
 	{
-
 		var configPath = Path.Combine(
 		Directory.GetCurrentDirectory(), "appsettings.tests.json");
 
@@ -28,7 +28,7 @@ public class DatabaseTestFixture
 		{
 			if (!_databaseInitialized)
 			{
-				using (var context = CreateContext())
+				using (var context = CreateContext(interceptors))
 				{
 					context.Database.EnsureDeleted();
 					context.Database.Migrate();
@@ -53,13 +53,23 @@ public class DatabaseTestFixture
 		return result;
 	}
 
-	protected ConcernsDbContext CreateContext()
+	public ConcernsDbContext CreateContext(IEnumerable<IInterceptor>? interceptors = null)
 	{
 		var userInfoService = new ServerUserInfoService()
 		{
 			UserInfo = new UserInfo() { Name = "Data.Tests@test.gov.uk", Roles = new[] { Claims.CaseWorkerRoleClaim } }
 		};
 
-		return new ConcernsDbContext(new DbContextOptionsBuilder<ConcernsDbContext>().UseSqlServer(_connectionString).Options, userInfoService);
+		return new ConcernsDbContext(new DbContextOptionsBuilder<ConcernsDbContext>().UseSqlServer(_connectionString).Options, userInfoService, interceptors);
+	}
+
+	public void SetEnvironmentVariable(string key, string value)
+	{
+		Environment.SetEnvironmentVariable(key, value);
+	}
+
+	public void ResetEnvironmentVariable(string key)
+	{
+		Environment.SetEnvironmentVariable(key, null);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/DatabaseFixtureBase.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/DatabaseFixtureBase.cs
@@ -8,7 +8,7 @@ namespace ConcernsCaseWork.Data.Tests;
 
 public class DatabaseTestFixture
 {
-	public readonly string? _connectionString;
+	private readonly string? _connectionString;
 
 	private static readonly object _lock = new();
 	private static bool _databaseInitialized;
@@ -61,15 +61,5 @@ public class DatabaseTestFixture
 		};
 
 		return new ConcernsDbContext(new DbContextOptionsBuilder<ConcernsDbContext>().UseSqlServer(_connectionString).Options, userInfoService, interceptors);
-	}
-
-	public void SetEnvironmentVariable(string key, string value)
-	{
-		Environment.SetEnvironmentVariable(key, value);
-	}
-
-	public void ResetEnvironmentVariable(string key)
-	{
-		Environment.SetEnvironmentVariable(key, null);
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/InterceptorTests/SqlCommandInterceptorTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/InterceptorTests/SqlCommandInterceptorTests.cs
@@ -1,0 +1,79 @@
+﻿using ConcernsCaseWork.Data.EFInterceptors;
+using ConcernsCaseWork.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Moq;
+using System.Data.Common;
+
+namespace ConcernsCaseWork.Data.Tests.InterceptorTests;
+
+[TestFixture]
+public class SqlCommandInterceptorTests
+{
+	private const string _envVarName = "ENABLE_DETAILED_SQL_LOGGING";
+	private DatabaseTestFixture _fixture;
+	private ConcernsDbContext _context;
+	private Mock<SqlCommandInterceptor> _sqlCommandInterceptorMock;
+
+	[OneTimeSetUp]
+	public void OneTimeSetUp()
+	{
+		// This ensures that the environment is consistent for the entire test class
+		_sqlCommandInterceptorMock = new Mock<SqlCommandInterceptor> { CallBase = true };
+		_fixture = new DatabaseTestFixture([_sqlCommandInterceptorMock.Object]);
+	}
+
+	[SetUp]
+	public void SetUp()
+	{
+		_context = _fixture.CreateContext([_sqlCommandInterceptorMock.Object]);
+	}
+
+	[TearDown]
+	public void TearDown()
+	{
+		Environment.SetEnvironmentVariable(_envVarName, null);
+	}
+
+	[OneTimeTearDown]
+	public void OneTimeTearDown()
+	{
+		// Clean up environment after all tests have run
+		Environment.SetEnvironmentVariable(_envVarName, null);
+	}
+
+	[Test]
+	public void Should_AddSqlCommandInterceptor_When_EnableDetailedSqlLoggingIsTrue()
+	{
+		// Arrange
+		_fixture.SetEnvironmentVariable(_envVarName, "true");
+
+		// Act
+		_context.Set<ConcernsCase>().AsNoTracking().FirstOrDefault();
+
+		// Assert
+		_sqlCommandInterceptorMock.Verify(
+			m => m.ReaderExecuting(It.IsAny<DbCommand>(), It.IsAny<CommandEventData>(), It.IsAny<InterceptionResult<DbDataReader>>()),
+			Times.AtLeastOnce,
+			"The SQL Command Interceptor should be called when ENABLE_DETAILED_SQL_LOGGING is set to true."
+		);
+	}
+
+	[Test]
+	public void Should_AddSqlCommandInterceptor_When_EnableDetailedSqlLoggingIsFalse()
+	{
+		// Arrange
+		_fixture.SetEnvironmentVariable(_envVarName, "false");
+
+		// Act
+		_context.Set<ConcernsCase>().AsNoTracking().FirstOrDefault();
+
+		// Assert
+		_sqlCommandInterceptorMock.Verify(
+			m => m.ReaderExecuting(It.IsAny<DbCommand>(), It.IsAny<CommandEventData>(), It.IsAny<InterceptionResult<DbDataReader>>()),
+			Times.Never,
+			"The SQL Command Interceptor should never be called when ENABLE_DETAILED_SQL_LOGGING is set to false."
+		);
+	}
+}
+

--- a/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/InterceptorTests/SqlCommandInterceptorTests.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data.Tests/InterceptorTests/SqlCommandInterceptorTests.cs
@@ -21,12 +21,15 @@ public class SqlCommandInterceptorTests
 		// This ensures that the environment is consistent for the entire test class
 		_sqlCommandInterceptorMock = new Mock<SqlCommandInterceptor> { CallBase = true };
 		_fixture = new DatabaseTestFixture([_sqlCommandInterceptorMock.Object]);
+		Environment.SetEnvironmentVariable(_envVarName, null);
+
 	}
 
 	[SetUp]
 	public void SetUp()
 	{
 		_context = _fixture.CreateContext([_sqlCommandInterceptorMock.Object]);
+		Environment.SetEnvironmentVariable(_envVarName, null);
 	}
 
 	[TearDown]
@@ -46,7 +49,7 @@ public class SqlCommandInterceptorTests
 	public void Should_AddSqlCommandInterceptor_When_EnableDetailedSqlLoggingIsTrue()
 	{
 		// Arrange
-		_fixture.SetEnvironmentVariable(_envVarName, "true");
+		Environment.SetEnvironmentVariable(_envVarName, "true");
 
 		// Act
 		_context.Set<ConcernsCase>().AsNoTracking().FirstOrDefault();
@@ -63,7 +66,7 @@ public class SqlCommandInterceptorTests
 	public void Should_AddSqlCommandInterceptor_When_EnableDetailedSqlLoggingIsFalse()
 	{
 		// Arrange
-		_fixture.SetEnvironmentVariable(_envVarName, "false");
+		Environment.SetEnvironmentVariable(_envVarName, "false");
 
 		// Act
 		_context.Set<ConcernsCase>().AsNoTracking().FirstOrDefault();

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsDbContext.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsDbContext.cs
@@ -25,7 +25,7 @@ namespace ConcernsCaseWork.Data
 		{
 		}
 
-		public ConcernsDbContext(DbContextOptions<ConcernsDbContext> options, IServerUserInfoService userInfoService, IEnumerable<IInterceptor>? interceptors = null)
+		public ConcernsDbContext(DbContextOptions<ConcernsDbContext> options, IServerUserInfoService userInfoService, IEnumerable<IInterceptor> interceptors = null)
 			: base(options)
 		{
 			Guard.Against.Null(userInfoService);
@@ -129,7 +129,7 @@ namespace ConcernsCaseWork.Data
 			}
 
 			var enableDetailedLogging = Environment.GetEnvironmentVariable("ENABLE_DETAILED_SQL_LOGGING");
-			bool isDetailedLoggingEnabled = !string.IsNullOrEmpty(enableDetailedLogging) && enableDetailedLogging.ToLower() == "true";
+			bool isDetailedLoggingEnabled = !string.IsNullOrEmpty(enableDetailedLogging) && enableDetailedLogging.Equals("true", StringComparison.OrdinalIgnoreCase);
 
 			// Ensure SqlCommandInterceptor is included based on the environment variable
 			if (isDetailedLoggingEnabled && !_interceptors.OfType<SqlCommandInterceptor>().Any())

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsDbContext.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsDbContext.cs
@@ -1,12 +1,14 @@
 using Ardalis.GuardClauses;
 using ConcernsCaseWork.Data.Auditing;
 using ConcernsCaseWork.Data.Conventions;
+using ConcernsCaseWork.Data.EFInterceptors;
 using ConcernsCaseWork.Data.Models;
 using ConcernsCaseWork.Data.Models.Concerns.TeamCasework;
 using ConcernsCaseWork.Data.Models.Decisions;
 using ConcernsCaseWork.Data.Models.Decisions.Outcome;
 using ConcernsCaseWork.UserContext;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -123,6 +125,14 @@ namespace ConcernsCaseWork.Data
 			{
 				optionsBuilder.UseConcernsSqlServer("Server=localhost;Database=sip;Integrated Security=true;TrustServerCertificate=True");
 			}
+
+			// Enable SQL Command Interceptor only if the following env variable exist and set to true
+			var enableDetailedLogging = Environment.GetEnvironmentVariable("ENABLE_DETAILED_SQL_LOGGING");
+			if (!string.IsNullOrEmpty(enableDetailedLogging) && enableDetailedLogging.ToLower() == "true")
+			{
+				optionsBuilder.AddInterceptors(new SqlCommandInterceptor());
+			}
+			base.OnConfiguring(optionsBuilder);
 		}
 
 		protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/EFInterceptors/SqlCommandInterceptor.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/EFInterceptors/SqlCommandInterceptor.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.EntityFrameworkCore.Diagnostics;
+using System.Data.Common;
+
+namespace ConcernsCaseWork.Data.EFInterceptors
+{
+	/// <summary>
+	/// Logs translated SQL commands
+	/// </summary>
+	public class SqlCommandInterceptor : DbCommandInterceptor
+	{
+		public override InterceptionResult<DbDataReader> ReaderExecuting(
+			DbCommand command,
+			CommandEventData eventData,
+			InterceptionResult<DbDataReader> result)
+		{
+			Console.WriteLine($"Executing command: {command.CommandText}");
+			return base.ReaderExecuting(command, eventData, result);
+		}
+	}
+}


### PR DESCRIPTION
**What is the change?**

Added an SQL Command interceptor to log executing commands in debug mode

**Why do we need the change?**

This helps viewing translated EF Queries to SQL Queries and be able debug or improve performance of the queries

**What is the impact?**

No impact on any environments as it needs a specific environment variable (ENABLE_DETAILED_SQL_LOGGING = true) to enable the feature

**Azure DevOps Ticket**
