### PR TITLE
Added design time dbcontext factory

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsCaseWork.Data.csproj
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsCaseWork.Data.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
@@ -14,7 +14,10 @@
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
       <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.6" />
-      <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+		<PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsDbContextFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsDbContextFactory.cs
@@ -1,0 +1,35 @@
+﻿using ConcernsCaseWork.UserContext;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
+
+namespace ConcernsCaseWork.Data
+{
+	public class ConcernsDbContextFactory : IDesignTimeDbContextFactory<ConcernsDbContext>
+	{
+		public ConcernsDbContext CreateDbContext(string[] args)
+		{
+			var optionsBuilder = new DbContextOptionsBuilder<ConcernsDbContext>();
+
+			var configPath = Path.Combine(Directory.GetCurrentDirectory(), "../ConcernsCaseWork/appsettings.json");
+
+			var configuration = new ConfigurationBuilder()
+				.AddJsonFile(configPath)
+				.Build();
+
+			var userInfoService = new ServerUserInfoService()
+			{
+				UserInfo = new UserInfo() { Name = "Design.Time@test.gov.uk", Roles = new[] { Claims.CaseWorkerRoleClaim } }
+			};
+
+			var connectionString = configuration.GetConnectionString("DefaultConnection");
+			optionsBuilder.UseSqlServer(connectionString);
+
+			var interceptors = new List<IInterceptor>();
+
+			return new ConcernsDbContext(optionsBuilder.Options, userInfoService, interceptors);
+		}
+	}
+}

--- a/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsDbContextFactory.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/ConcernsDbContextFactory.cs
@@ -3,10 +3,12 @@ using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using System.Diagnostics.CodeAnalysis;
 
 
 namespace ConcernsCaseWork.Data
 {
+	[ExcludeFromCodeCoverage]
 	public class ConcernsDbContextFactory : IDesignTimeDbContextFactory<ConcernsDbContext>
 	{
 		public ConcernsDbContext CreateDbContext(string[] args)


### PR DESCRIPTION
**What is the change?**

Added design time dbcontext factory

**Why do we need the change?**

This helps performing migration at the design time specially when optional parameters been used in the dbcontext constructor

**What is the impact?**

**Azure DevOps Ticket**
