### PR TITLE
Branch protection workflow

### DIFF
--- a/.github/workflows/branch-protection-checks.yml
+++ b/.github/workflows/branch-protection-checks.yml
@@ -1,0 +1,25 @@
+name: Validate source branch
+
+on:
+  pull_request:
+    branches:
+      - main
+      - staging
+
+jobs:
+  check:
+    name: Incoming branch validation
+    runs-on: ubuntu-latest
+    steps:
+      - id: branch
+        name: Check branch name
+        run: |
+          GIT_BRANCH=${{ github.head_ref }}
+          if [[ "$GIT_BRANCH" =~ ^hotfix/*|^feature/* ]];
+          then
+            echo "'$GIT_BRANCH' is a permitted branch"
+            exit 0
+          else
+            echo "'$GIT_BRANCH' is not a permitted branch"
+            exit 1
+          fi


### PR DESCRIPTION
* This CI test will validate the incoming branch name to ensure it starts with `feature/` or `hotfix/` when used in a Pull Request against `staging` or `main`

This CI will pass to demonstrate the workflow is working as intended