### PR TITLE
Open dependencies against main and staging

### DIFF
--- a/.github/workflows/branch-protection-checks.yml
+++ b/.github/workflows/branch-protection-checks.yml
@@ -15,7 +15,7 @@ jobs:
         name: Check branch name
         run: |
           GIT_BRANCH=${{ github.head_ref }}
-          if [[ "$GIT_BRANCH" =~ ^hotfix/*|^feature/* ]];
+          if [[ "$GIT_BRANCH" =~ ^hotfix/*|^feature/*|^renovate/* ]];
           then
             echo "'$GIT_BRANCH' is a permitted branch"
             exit 0

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
   ],
   "timezone": "Europe/London",
   "minimumReleaseAge": "7 days",
+  "baseBranches": ["main", "staging"],
   "automergeSchedule": ["after 10am every weekday", "before 4pm every weekday"],
   "labels": ["dependencies", "renovate"],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
- Tell Renovate to track PRs against `main` and `staging` branches