### PR TITLE
Fixed an issue where when the cache is expired the page throws an exception

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
@@ -5,6 +5,7 @@ using ConcernsCaseWork.Logging;
 using ConcernsCaseWork.Models;
 using ConcernsCaseWork.Models.CaseActions;
 using ConcernsCaseWork.Pages.Base;
+using ConcernsCaseWork.Redis.Models;
 using ConcernsCaseWork.Redis.Users;
 using ConcernsCaseWork.Service.Permissions;
 using ConcernsCaseWork.Services.Actions;
@@ -245,15 +246,18 @@ namespace ConcernsCaseWork.Pages.Case.Management
 		
 		private async Task UpdateCacheService(CaseModel model)
 		{
-			var userState = await _cachedService.GetData(GetUserName());
-			var trustUkPrn = userState?.TrustUkPrn;
-			if (trustUkPrn == null)
+			var userName = GetUserName();
+
+			var userState = await _cachedService.GetData(userName);
+
+			if (userState?.TrustUkPrn != null)
 			{
-				if (userState != null)
-					userState.TrustUkPrn = model.TrustUkPrn;
-				await _cachedService.StoreData(GetUserName(), userState);
+				return;
 			}
-			
+
+			if (userState != null)
+					userState.TrustUkPrn = model.TrustUkPrn;
+				await _cachedService.StoreData(userName, userState);
 		}
 
 		public async Task<IActionResult> OnGetPaginatedActiveCases(string trustUkPrn, int pageNumber)

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Index.cshtml.cs
@@ -246,11 +246,12 @@ namespace ConcernsCaseWork.Pages.Case.Management
 		private async Task UpdateCacheService(CaseModel model)
 		{
 			var userState = await _cachedService.GetData(GetUserName());
-			var trustUkPrn = userState.TrustUkPrn;
+			var trustUkPrn = userState?.TrustUkPrn;
 			if (trustUkPrn == null)
 			{
-				userState.TrustUkPrn = model.TrustUkPrn;
-				await _cachedService.StoreData(userState.UserName, userState);
+				if (userState != null)
+					userState.TrustUkPrn = model.TrustUkPrn;
+				await _cachedService.StoreData(GetUserName(), userState);
 			}
 			
 		}


### PR DESCRIPTION
**What is the change?**

Checking the suer state in the cache if it doesn't exist catch the exception and create a new cached item!

**Why do we need the change?**

It throws an exception if the cache is expired and the suer tries to access a case page

**What is the impact?**

No impact

**Azure DevOps Ticket**

https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_sprints/taskboard/Common%20Architecture/Academies-and-Free-Schools-SIP/Q2-%20Sprint%205?workitem=179198