### PR TITLE
Add the branch name to the concurrency group

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -14,7 +14,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.environment }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.environment }}-${{ github.ref_name }}
 
 jobs:
   set-env:


### PR DESCRIPTION
* this will stop queues when deploying to both staging and production
