### PR TITLE
Automatically update to latest security fixes for upstream packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG COMMIT_SHA=not-set
 FROM "mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION}-azurelinux3.0" AS builder
 ARG COMMIT_SHA
 WORKDIR /build
-RUN ["tdnf", "update"]
+RUN ["tdnf", "update", "--security", "-y"]
 RUN ["tdnf", "install", "-y", "jq"]
 RUN ["tdnf", "clean", "all"]
 COPY ConcernsCaseWork/. .


### PR DESCRIPTION
**What is the change?**
- Fixes the issue wherein `tdnf update` might expect user input to approve the installation of new packages
- Reduces scope of update&install check to only include security packages

**Why do we need the change?**
- Dockerfile wont build if tdnf update results in available updates