### PR TITLE
Updated renovate config to extend the shared config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,28 +1,29 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended",
-    "group:linters",
-    "group:test",
-    "schedule:weekly",
-    ":approveMajorUpdates",
-    ":automergeLinters",
-    ":automergePatch",
-    ":automergePr",
-    ":automergeRequireAllStatusChecks",
-    ":automergeTesters",
-    ":maintainLockFilesWeekly",
-    ":dependencyDashboard"
-  ],
-  "timezone": "Europe/London",
-  "minimumReleaseAge": "7 days",
-  "baseBranches": ["main", "staging"],
-  "automergeSchedule": ["after 10am every weekday", "before 4pm every weekday"],
-  "labels": ["dependencies", "renovate"],
-  "vulnerabilityAlerts": {
-    "addLabels": ["security"]
-  },
-  "major": {
-    "addLabels": ["major"]
-  }
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"config:recommended",
+		"group:linters",
+		"group:test",
+		"schedule:weekly",
+		":approveMajorUpdates",
+		":automergeLinters",
+		":automergePatch",
+		":automergePr",
+		":automergeRequireAllStatusChecks",
+		":automergeTesters",
+		":maintainLockFilesWeekly",
+		":dependencyDashboard",
+		"github>DFE-Digital/rsd-renovate-config"
+	],
+	"timezone": "Europe/London",
+	"minimumReleaseAge": "7 days",
+	"baseBranches": [ "main", "staging" ],
+	"automergeSchedule": [ "after 10am every weekday", "before 4pm every weekday" ],
+	"labels": [ "dependencies", "renovate" ],
+	"vulnerabilityAlerts": {
+		"addLabels": [ "security" ]
+	},
+	"major": {
+		"addLabels": [ "major" ]
+	}
 }


### PR DESCRIPTION
**What is the change?**

Updated the renovate.json to extend shared config 

**Why do we need the change?**

Centralizing the renovate configuration

