### PR TITLE
Simplify workflow and expose SQL connection string correctly

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -34,11 +34,6 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     environment: dev
-    env:
-      # Note: The database name may be overridden by the tests
-      CONNECTION_STRING: 'Server=localhost,1433;Database=integrationtests;User Id=sa;Password=P1swrd!$;TrustServerCertificate=True'
-      CONNECTION_STRING_KEY: 'ConnectionStrings:DefaultConnection'
-
     services:
       sql-server:
         image: mcr.microsoft.com/mssql/server:2022-latest
@@ -47,7 +42,6 @@ jobs:
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: P1swrd!$
-
       redis:
         image: redis:alpine
         ports:
@@ -57,7 +51,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -84,23 +77,22 @@ jobs:
 
       - name: Install SonarCloud scanners
         run: dotnet tool install --global dotnet-sonarscanner
-        
+
       - name: Install dotnet reportgenerator
         run: dotnet tool install --global dotnet-reportgenerator-globaltool
 
       - name: Add nuget package source
         run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"
 
-      - name: Restore dependencies
-        run: dotnet restore ConcernsCaseWork/ConcernsCaseWork.sln
-
       - name: Build solution, test and run SonarCloud scanner
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          # Note: The database name may be overridden by the tests
+          ConnectionStrings__DefaultConnection: 'Server=localhost,1433;Database=integrationtests;User Id=sa;Password=P1swrd!$;TrustServerCertificate=True'
         run: |
           dotnet-sonarscanner begin /d:sonar.scanner.skipJreProvisioning=true /k:"DFE-Digital_record-concerns-support-trusts" /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=./ConcernsCaseWork/CoverageReport/SonarQube.xml
-          dotnet build ConcernsCaseWork/ConcernsCaseWork.sln --no-restore
-          dotnet test ConcernsCaseWork/ConcernsCaseWork.sln --no-build --verbosity normal --collect:"XPlat Code Coverage" --environment "${{env.CONNECTION_STRING_KEY}}"="${{env.CONNECTION_STRING}}" --filter "FullyQualifiedName!~ConcernsCaseWork.Integration.Tests"
+          dotnet build ConcernsCaseWork/ConcernsCaseWork.sln
+          dotnet test ConcernsCaseWork/ConcernsCaseWork.sln --no-build --verbosity normal --collect:"XPlat Code Coverage"
           reportgenerator -reports:"./**/coverage.cobertura.xml" -targetdir:./ConcernsCaseWork/CoverageReport -reporttypes:SonarQube
           dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
**What is the change?**
- Removes `--filter "FullyQualifiedName!~ConcernsCaseWork.Integration.Tests"` because this dir doesn't exist anyway so it's useless.
- Scoped the `env` definitions to the specific step that runs `dotnet test`
- Updated the env key to more accurately represent what dotnet expects
- Removed the extra dotnet restore step
