### PR TITLE
Add Sonar Quality Gate

### DIFF
--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -34,11 +34,6 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     environment: dev
-    env:
-      # Note: The database name may be overridden by the tests
-      CONNECTION_STRING: 'Server=localhost,1433;Database=integrationtests;User Id=sa;Password=P1swrd!$;TrustServerCertificate=True'
-      CONNECTION_STRING_KEY: 'ConnectionStrings:DefaultConnection'
-
     services:
       sql-server:
         image: mcr.microsoft.com/mssql/server:2022-latest
@@ -47,7 +42,6 @@ jobs:
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: P1swrd!$
-
       redis:
         image: redis:alpine
         ports:
@@ -57,7 +51,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -91,16 +84,15 @@ jobs:
       - name: Add nuget package source
         run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"
 
-      - name: Restore dependencies
-        run: dotnet restore ConcernsCaseWork/ConcernsCaseWork.sln
-
       - name: Build solution, test and run SonarCloud scanner
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          # Note: The database name may be overridden by the tests
+          ConnectionStrings__DefaultConnection: 'Server=localhost,1433;Database=integrationtests;User Id=sa;Password=P1swrd!$;TrustServerCertificate=True'
         run: |
           dotnet-sonarscanner begin /d:sonar.scanner.skipJreProvisioning=true /k:"DFE-Digital_record-concerns-support-trusts" /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=./ConcernsCaseWork/CoverageReport/SonarQube.xml
-          dotnet build ConcernsCaseWork/ConcernsCaseWork.sln --no-restore
-          dotnet test ConcernsCaseWork/ConcernsCaseWork.sln --no-build --verbosity normal --collect:"XPlat Code Coverage" --environment "${{env.CONNECTION_STRING_KEY}}"="${{env.CONNECTION_STRING}}" --filter "FullyQualifiedName!~ConcernsCaseWork.Integration.Tests"
+          dotnet build ConcernsCaseWork/ConcernsCaseWork.sln
+          dotnet test ConcernsCaseWork/ConcernsCaseWork.sln --no-build --verbosity normal --collect:"XPlat Code Coverage"
           reportgenerator -reports:"./**/coverage.cobertura.xml" -targetdir:./ConcernsCaseWork/CoverageReport -reporttypes:SonarQube
           dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -76,7 +76,7 @@ jobs:
           # Note: The database name may be overridden by the tests
           ConnectionStrings__DefaultConnection: 'Server=localhost,1433;Database=integrationtests;User Id=sa;Password=P1swrd!$;TrustServerCertificate=True'
         run: |
-          dotnet-sonarscanner begin /d:sonar.scanner.skipJreProvisioning=true /k:"DFE-Digital_record-concerns-support-trusts" /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=./ConcernsCaseWork/CoverageReport/SonarQube.xml
+          dotnet-sonarscanner begin /d:sonar.qualitygate.wait=true /d:sonar.scanner.skipJreProvisioning=true /k:"DFE-Digital_record-concerns-support-trusts" /o:"dfe-digital" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.coverageReportPaths=./ConcernsCaseWork/CoverageReport/SonarQube.xml
           dotnet build ConcernsCaseWork/ConcernsCaseWork.sln
           dotnet test ConcernsCaseWork/ConcernsCaseWork.sln --no-build --verbosity normal --collect:"XPlat Code Coverage"
           reportgenerator -reports:"./**/coverage.cobertura.xml" -targetdir:./ConcernsCaseWork/CoverageReport -reporttypes:SonarQube

--- a/.github/workflows/continuous-integration-dotnet.yml
+++ b/.github/workflows/continuous-integration-dotnet.yml
@@ -1,39 +1,18 @@
-﻿name: .NET Build and Test
+﻿name: .NET
 
 on:
   push:
-    branches:
-    - main
-    paths:
-    - 'ConcernsCaseWork/ConcernsCaseWork*/**'
-    - '!ConcernsCaseWork/ConcernsCaseWork.CypressTests/**'
+    branches: [ main ]
   pull_request:
-    branches: [ main, release/** ]
-    types: [ opened, synchronize, reopened ]
-    paths:
-    - 'ConcernsCaseWork/ConcernsCaseWork*/**'
-    - '!ConcernsCaseWork/ConcernsCaseWork.CypressTests/**'
 
 env:
-  JAVA_VERSION: '17'
+  JAVA_VERSION: '21'
+  DOTNET_VERSION: 8.0.x
 
 jobs:
-  appsettings:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Check appsettings validity
-        run: |
-          DIRECTORY=./ConcernsCaseWork/ConcernsCaseWork
-          for i in "$DIRECTORY"/appsettings*.json; do
-            echo "$i" && jq . "$i"
-          done
-
   build-test:
-    runs-on: ubuntu-latest
-    environment: dev
+    name: Build and Test
+    runs-on: ubuntu-24.04
     services:
       sql-server:
         image: mcr.microsoft.com/mssql/server:2022-latest
@@ -57,12 +36,19 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones disabled for a better relevancy of SC analysis
 
-      - name: Setup .NET
+      - name: Check appsettings validity
+        run: |
+          DIRECTORY=./ConcernsCaseWork/ConcernsCaseWork
+          for i in "$DIRECTORY"/appsettings*.json; do
+            echo "$i" && jq . "$i"
+          done
+
+      - name: Setup .NET ${{ env.DOTNET_VERSION }}
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
@@ -75,11 +61,10 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      - name: Install SonarCloud scanners
-        run: dotnet tool install --global dotnet-sonarscanner
-
-      - name: Install dotnet reportgenerator
-        run: dotnet tool install --global dotnet-reportgenerator-globaltool
+      - name: Install SonarCloud tools
+        run: |
+          dotnet tool install --global dotnet-sonarscanner
+          dotnet tool install --global dotnet-reportgenerator-globaltool
 
       - name: Add nuget package source
         run: dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/DFE-Digital/index.json"


### PR DESCRIPTION
**What is the change?**
- Correctly inherit the Connection String for the MSSQL Server
- Remove Path filters so that we can make the workflow a required quality gate
- Update the Java SDK and pin both that and the .NET versions as env vars
- Combine the appsettings job into the main workflow steps to reduce the runner count
- Removed the unused test filter

**Azure DevOps Ticket**
[User Story 206444](https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/206444): Create Sonar quality gate on all repos