### PR TITLE
Added DB retry logic

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.Data/DbContextExtensions.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.Data/DbContextExtensions.cs
@@ -8,7 +8,13 @@ public static class DbContextExtensions
 	{
 		optionsBuilder.UseSqlServer(
 			connectionString,
-			opt => opt.MigrationsHistoryTable("__EfMigrationsHistory", "concerns"));
+			opt => {
+				opt.MigrationsHistoryTable("__EfMigrationsHistory", "concerns");
+				opt.EnableRetryOnFailure(
+					maxRetryCount: 2,
+					maxRetryDelay: TimeSpan.FromSeconds(5),
+					errorNumbersToAdd: null);
+			});
 		return optionsBuilder;
 	}
 }


### PR DESCRIPTION
**What is the change?**
Added database retry logic for stopping to generate db timeout healthcheck alert
**Why do we need the change?**
Transient network issues that occasionally cause the healthcheck to report a timeout
**What is the impact?**
No impact on user
**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/225653