### PR TITLE
Design - Inclusion of new Decision Type - Financial Recovery

### DIFF
--- a/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Decisions/DecisionType.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork.API.Contracts/Decisions/DecisionType.cs
@@ -35,6 +35,9 @@ namespace ConcernsCaseWork.API.Contracts.Decisions
 		EsfaApproval = 10,
 
 		[Description("Freedom of Information exemptions (FOI) ")]
-		FreedomOfInformationExemptions = 11
+		FreedomOfInformationExemptions = 11,
+
+		[Description("Financial Recovery of Fraud or irregularity")]
+		FinancialRecoveryOfFraudOrIrregularity = 12
 	}
 }

--- a/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case-regions-group.cy.ts
+++ b/ConcernsCaseWork/ConcernsCaseWork.CypressTests/cypress/e2e/casework-regression/create-case-regions-group.cy.ts
@@ -293,7 +293,8 @@ describe("Creating a case", () => {
             editDecisionPage.hasTypeOfDecisionOptions([
                 "Notice to Improve (NTI)",
                 "Section 128 (S128)",
-                "Freedom of Information exemptions (FOI)"
+                "Freedom of Information exemptions (FOI)",
+                "Financial Recovery of Fraud or irregularity"
             ]);
 
             Logger.log("Creating a decision");

--- a/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml.cs
+++ b/ConcernsCaseWork/ConcernsCaseWork/Pages/Case/Management/Action/Decision/Add.cshtml.cs
@@ -273,6 +273,11 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Decision
 				{
 					Id = DecisionType.FreedomOfInformationExemptions,
 					Hint = "If information qualifies as an exemption to the Freedom of Information Act, we can decline to release information. Some exemptions require ministerial approval. You must contact the FOI team if you think you need to apply an exemption to your FOI response or if you have any concerns about releasing information as part of a response."
+				},
+				new DecisionTypeQuestionModel()
+				{
+					Id = DecisionType.FinancialRecoveryOfFraudOrIrregularity,
+					Hint = "Some cases of fraud or irregularity identified within an accademy trust may be considered for recovery as per the departments internal processes. Assessment and recommendation will result in a decision to recover an amount of funds from the trust through GAG abatement or decide recovery of funds is not appropriate and therefore recorded as a claim waived in the departments accounts. A decision to recover funds could be a condition of an Notice to Improve."
 				}
 			};
 
@@ -286,7 +291,9 @@ namespace ConcernsCaseWork.Pages.Case.Management.Action.Decision
 			var result = allDecisionTypes.Where(
 				q => q.Id == DecisionType.NoticeToImprove || 
 				q.Id == DecisionType.Section128 || 
-				q.Id == DecisionType.FreedomOfInformationExemptions).ToList();
+				q.Id == DecisionType.FreedomOfInformationExemptions ||
+				q.Id == DecisionType.FinancialRecoveryOfFraudOrIrregularity
+			).ToList();
 
 			return result;
 		}


### PR DESCRIPTION
**What is the change?**
Add new checkbox option for Financial Recovery of Fraud or irregularity
<img width="394" height="386" alt="image" src="https://github.com/user-attachments/assets/5dde4a60-1d0e-442a-9dd1-ba8864785fe8" />

<img width="461" height="320" alt="image" src="https://github.com/user-attachments/assets/8454e2a3-ff85-4099-ae12-0af337e427a5" />

**Why do we need the change?**

**What is the impact?**

**Azure DevOps Ticket**
https://dfe-gov-uk.visualstudio.com/Academies-and-Free-Schools-SIP/_workitems/edit/237612